### PR TITLE
Set `job` label to the app name

### DIFF
--- a/lib/cf_app_discovery/target_configuration.rb
+++ b/lib/cf_app_discovery/target_configuration.rb
@@ -57,6 +57,7 @@ class CfAppDiscovery
             __param_cf_app_guid: target.guid,
             __param_cf_app_instance_index: index.to_s,
             cf_app_instance: index.to_s,
+            job: target.name,
           }
         }
       end

--- a/spec/cf_app_discovery/target_configuration_spec.rb
+++ b/spec/cf_app_discovery/target_configuration_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
           __param_cf_app_guid: "app-1-guid",
           __param_cf_app_instance_index: "0",
           cf_app_instance: "0",
+          job: "app-1",
         },
       },
       {
@@ -76,6 +77,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
           __param_cf_app_guid: "app-1-guid",
           __param_cf_app_instance_index: "1",
           cf_app_instance: "1",
+          job: "app-1",
         },
       },
     ]
@@ -88,6 +90,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
           __param_cf_app_guid: "app-2-guid",
           __param_cf_app_instance_index: "0",
           cf_app_instance: "0",
+          job: "app-2",
         },
       },
     ]


### PR DESCRIPTION
As the prometheus docs say [1]: an instance is an endpoint you can
scrape, while a job is a collection of instances with the same purpose,
replicated for scalability or reliability.

We currently specify neither `job` nor `instance` in our configuration.
This means that `job` is automatically set to the `job_name` in the
toplevel configuration file that sets up the file_sd_configs (in our
case, `paas-targets`; and `instance` is automatically set to the
host:port from the target URL.

In practice this means that `job` is useless and `instance` is
misleading.

I propose that we set `job` to the PaaS app name, and `instance` to some
string like `app-1/0`, based on app name and instance number.  However
we can't change `instance` at the moment because it's already used in a
number of dashboard queries. 

This commit just sets the `job` label.  Then we can migrate existing
dashboards to use `job` instead of `instance`, and finally we can set
`instance` to our desired value (and we can remove the cf_app_instance
label at the same time).

[1] https://prometheus.io/docs/concepts/jobs_instances/