### PR TITLE
Added missing ? to casecmp

### DIFF
--- a/lib/cf_app_discovery/filestore_manager_factory.rb
+++ b/lib/cf_app_discovery/filestore_manager_factory.rb
@@ -1,7 +1,7 @@
 class CfAppDiscovery
   class FilestoreManagerFactory
     def self.filestore_manager_builder(environment, targets_path)
-      if environment.casecmp('local')
+      if environment.casecmp?('local')
         LocalManager.new(targets_path: targets_path, folders: %w(active inactive))
       else
         S3Manager.new(bucket_name: 'gds-prometheus-targets')


### PR DESCRIPTION
Without the `?` it is always True, therefore it uses the LocalManager rather than S3Manager. 

This causes errors when doing updates, the fix will get it to use the correct file manager.