### PR TITLE
Set clock interval to 60 seconds rather than 300 seconds

### DIFF
--- a/bin/clock.rb
+++ b/bin/clock.rb
@@ -6,7 +6,7 @@ module Clockwork
     system(job)
   end
 
-  every(300, 'Update targets') {
+  every(60, 'Update targets') {
     `rake update_targets`
   }
 end


### PR DESCRIPTION
## What 

In order to reduce the possibility of being out of sync between blue-green deployments which will cause gaps in metrics the clock interval has been lowered. 