### PR TITLE
Add instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '~> 2.5.1'
 gem "aws-sdk-s3"
 gem "cf-uaa-lib"
 gem "clockwork"
+gem "prometheus-client"
 gem "rake"
 # Needed to load the Rakefile
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    prometheus-client (0.8.0)
+      quantile (~> 0.2.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -62,6 +64,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.2)
+    quantile (0.2.1)
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
@@ -128,6 +131,7 @@ DEPENDENCIES
   clockwork
   factory_bot
   govuk-lint
+  prometheus-client
   pry-byebug
   rack-test
   rake
@@ -139,4 +143,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,4 @@ task :lint do
   system("bundle exec govuk-lint-ruby")
 end
 
-task :update_targets do
-  system("./bin/cf_app_discovery")
-end
-
 task default: %i[spec lint]

--- a/bin/clock.rb
+++ b/bin/clock.rb
@@ -7,6 +7,6 @@ module Clockwork
   end
 
   every(60, 'Update targets') {
-    `rake update_targets`
+    system("curl", "-d", "", "#{ENV.fetch("BROKER_ENDPOINT")}/update-targets")
   }
 end

--- a/config.ru
+++ b/config.ru
@@ -7,7 +7,7 @@ require 'prometheus/middleware/exporter'
 require 'cf_app_discovery'
 
 use Rack::Deflater
-use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Collector, metrics_prefix: 'observe_broker_http'
 use Prometheus::Middleware::Exporter
 
 run CfAppDiscovery::ServiceBroker

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,13 @@
-$LOAD_PATH.unshift("lib")
+$LOAD_PATH.unshift('lib')
 
-require "cf_app_discovery"
+require 'rack'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+require 'cf_app_discovery'
+
+use Rack::Deflater
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
 
 run CfAppDiscovery::ServiceBroker

--- a/lib/cf_app_discovery/service_broker.rb
+++ b/lib/cf_app_discovery/service_broker.rb
@@ -71,6 +71,11 @@ class CfAppDiscovery
       render({})
     end
 
+    post "/update-targets" do
+      CfAppDiscovery.run(api_endpoint: settings.api_endpoint, uaa_endpoint: settings.uaa_endpoint, uaa_username: settings.uaa_username, uaa_password: settings.uaa_password, paas_domain: settings.paas_domain, targets_path: settings.targets_path, environment: settings.environment)
+      render({})
+    end
+
   private
 
     def filestore_manager

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -9,6 +9,7 @@ defaults: &defaults
     AWS_REGION: eu-west-1
     API_ENDPOINT: https://api.cloud.service.gov.uk
     UAA_ENDPOINT: https://uaa.cloud.service.gov.uk
+    BROKER_ENDPOINT: https://prometheus-service-broker.cloudapps.digital
     PAAS_DOMAIN: cloudapps.digital
     TARGETS_PATH: none
     ENVIRONMENT: paas

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -9,6 +9,7 @@ defaults: &defaults
     AWS_REGION: eu-west-1
     API_ENDPOINT: https://api.cloud.service.gov.uk
     UAA_ENDPOINT: https://uaa.cloud.service.gov.uk
+    BROKER_ENDPOINT: https://prometheus-service-broker-staging.cloudapps.digital
     PAAS_DOMAIN: cloudapps.digital
     TARGETS_PATH: none
     ENVIRONMENT: paas

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ defaults: &defaults
     AWS_REGION: eu-west-1
     API_ENDPOINT: https://api.cloud.service.gov.uk
     UAA_ENDPOINT: https://uaa.cloud.service.gov.uk
+    BROKER_ENDPOINT: https://prometheus-service-broker-dev.cloudapps.digital
     PAAS_DOMAIN: cloudapps.digital
     TARGETS_PATH: none
     ENVIRONMENT: paas


### PR DESCRIPTION
This adds prometheus instrumentation to the service broker.

There are a few things I did:

 - add prometheus instrumentation to the service broker http server
 - move the target-updater functionality from the clockwork app to the main service broker http server, so that it can be more easily instrumented
 - added instrumentation to the cloud foundry client code, so that we can see how many of each API call we are making

This has already been deployed to the staging service broker for testing purposes, so if you want to see what it looks like, have a look at staging prometheus.