### PR TITLE
Run the linter as well as the tests in CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,15 @@ require: rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.5.1
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
  - 2.5.1
 script:
   - bundle exec rspec
+  - bundle exec govuk-lint-ruby --diff
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rake"
 gem "rspec"
 gem "sinatra"
 
-group :development do
+group :development, :test do
   gem "factory_bot"
   gem "govuk-lint"
   gem 'pry-byebug'

--- a/bin/clock.rb
+++ b/bin/clock.rb
@@ -7,6 +7,6 @@ module Clockwork
   end
 
   every(60, 'Update targets') {
-    system("curl", "-d", "", "#{ENV.fetch("BROKER_ENDPOINT")}/update-targets")
+    system("curl", "-d", "", "#{ENV.fetch('BROKER_ENDPOINT')}/update-targets")
   }
 end

--- a/spec/cf_app_discovery/auth_spec.rb
+++ b/spec/cf_app_discovery/auth_spec.rb
@@ -3,10 +3,7 @@ require "spec_helper"
 RSpec.describe CfAppDiscovery::Auth do
   include StubHelper
 
-  let(:endpoint) { StubbableEndpoint::Auth }
-  before { stub_endpoint(endpoint) }
-
-  subject do
+  subject(:auth) do
     described_class.new(
       uaa_endpoint: "http://uaa.example.com",
       uaa_username: "uaa-username",
@@ -14,7 +11,11 @@ RSpec.describe CfAppDiscovery::Auth do
     )
   end
 
+  let(:endpoint) { StubbableEndpoint::Auth }
+
+  before { stub_endpoint(endpoint) }
+
   it "returns the oauth access token" do
-    expect(subject.access_token).to eq("dummy-oauth-token")
+    expect(auth.access_token).to eq("dummy-oauth-token")
   end
 end

--- a/spec/cf_app_discovery/cleaner_spec.rb
+++ b/spec/cf_app_discovery/cleaner_spec.rb
@@ -1,7 +1,11 @@
 require "spec_helper"
 
 RSpec.describe CfAppDiscovery::Cleaner do
-  subject { described_class.new(filestore_manager: LocalManager.new(targets_path: targets_path, folders: %w(active inactive))) }
+  subject(:cleaner) do
+    described_class.new(
+      filestore_manager: LocalManager.new(targets_path: targets_path, folders: %w(active inactive))
+    )
+  end
 
   let(:targets_path) { Dir.mktmpdir }
   let(:active_targets_path) {
@@ -27,7 +31,7 @@ RSpec.describe CfAppDiscovery::Cleaner do
     FileUtils.touch(configured_target_filename)
     FileUtils.touch(stopped_target_filename)
 
-    expect { subject.move_stopped_targets([stopped_target]) }
+    expect { cleaner.move_stopped_targets([stopped_target]) }
       .to change { File.exist?(configured_target_filename) }
       .from(true)
       .to(false)
@@ -40,7 +44,7 @@ RSpec.describe CfAppDiscovery::Cleaner do
     FileUtils.touch(stopped_target_filename)
     FileUtils.touch(current_target_filename)
 
-    expect { subject.move_stopped_targets([stopped_target]) }
+    expect { cleaner.move_stopped_targets([stopped_target]) }
       .to change { File.exist?(stopped_target_filename) }
       .from(true)
       .to(false)
@@ -54,7 +58,7 @@ RSpec.describe CfAppDiscovery::Cleaner do
     FileUtils.touch(stopped_target_filename)
     FileUtils.touch(current_target_filename)
 
-    subject.remove_old_target(current_target.guid)
+    cleaner.remove_old_target(current_target.guid)
 
     expect(File.exist?(stopped_target_filename)).to eq(false)
     expect(File.exist?(current_target_filename)).to eq(false)

--- a/spec/cf_app_discovery/client_spec.rb
+++ b/spec/cf_app_discovery/client_spec.rb
@@ -8,21 +8,20 @@ RSpec.describe CfAppDiscovery::Client do
   expected_responses_file = File.read("#{spec_root}/fixtures/expected_responses.json")
   expected_responses = JSON.parse(expected_responses_file, symbolize_names: true)
 
-  let(:first_page) { StubbableEndpoint::Apps }
-  let(:second_page) { StubbableEndpoint::AppsPage2 }
+  before do
+    stub_endpoint(first_page)
+    stub_endpoint(second_page)
+    stub_endpoint(StubbableEndpoint::Domain1)
+    stub_endpoint(StubbableEndpoint::Domain2)
+    stub_endpoint(StubbableEndpoint::Org1)
+    stub_endpoint(StubbableEndpoint::Routes1)
+    stub_endpoint(StubbableEndpoint::Routes2)
+    stub_endpoint(StubbableEndpoint::Routes3)
+    stub_endpoint(StubbableEndpoint::Routes4)
+    stub_endpoint(StubbableEndpoint::Space1)
+  end
 
-  before { stub_endpoint(first_page) }
-  before { stub_endpoint(second_page) }
-  before { stub_endpoint(StubbableEndpoint::Domain1) }
-  before { stub_endpoint(StubbableEndpoint::Domain2) }
-  before { stub_endpoint(StubbableEndpoint::Org1) }
-  before { stub_endpoint(StubbableEndpoint::Routes1) }
-  before { stub_endpoint(StubbableEndpoint::Routes2) }
-  before { stub_endpoint(StubbableEndpoint::Routes3) }
-  before { stub_endpoint(StubbableEndpoint::Routes4) }
-  before { stub_endpoint(StubbableEndpoint::Space1) }
-
-  subject do
+  subject(:client) do
     described_class.new(
       api_endpoint: "http://api.example.com",
       api_token: "dummy-oauth-token",
@@ -30,10 +29,13 @@ RSpec.describe CfAppDiscovery::Client do
     )
   end
 
+  let(:first_page) { StubbableEndpoint::Apps }
+  let(:second_page) { StubbableEndpoint::AppsPage2 }
+
   it "returns the apps data from the api" do
     first_page.response_body.fetch(:resources)
     second_page.response_body.fetch(:resources)
 
-    expect(subject.apps).to eq(expected_responses)
+    expect(client.apps).to eq(expected_responses)
   end
 end

--- a/spec/cf_app_discovery/filter_spec.rb
+++ b/spec/cf_app_discovery/filter_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 RSpec.describe CfAppDiscovery::Filter do
+  subject(:filter) { described_class.new }
+
   let(:targets) do
     [
       CfAppDiscovery::Target.new(
@@ -36,11 +38,11 @@ RSpec.describe CfAppDiscovery::Filter do
     ]
   end
 
-  it "should filter target not running" do
-    expect(subject.filter_stopped(targets)).to eq [targets.first, targets.last]
+  it "filters target not running" do
+    expect(filter.filter_stopped(targets)).to eq [targets.first, targets.last]
   end
 
-  it "should filter target not configured for prometheus" do
-    expect(subject.filter_prometheus_available(targets, ["app-3-guid"])).to eq [targets.last]
+  it "filters target not configured for prometheus" do
+    expect(filter.filter_prometheus_available(targets, ["app-3-guid"])).to eq [targets.last]
   end
 end

--- a/spec/cf_app_discovery/paginator_spec.rb
+++ b/spec/cf_app_discovery/paginator_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe CfAppDiscovery::Paginator do
     end
   end
 
-  let(:client) { FakeClient.new }
-
-  subject do
+  subject(:paginator) do
     described_class.new { |url| client.apps(url) }
   end
 
+  let(:client) { FakeClient.new }
+
   it "yields pages until there's no next_url in the result" do
-    expect(subject.to_a).to eq [
+    expect(paginator.to_a).to eq [
       { title: "First", next_url: "/second-page" },
       { title: "Second", next_url: "/third-page" },
       { title: "Third", next_url: nil },

--- a/spec/cf_app_discovery/parser_spec.rb
+++ b/spec/cf_app_discovery/parser_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 RSpec.describe CfAppDiscovery::Parser do
+  subject(:parser) do
+    described_class.new(api_response)
+  end
+
   let(:api_response) do
     [
       {
@@ -45,11 +49,9 @@ RSpec.describe CfAppDiscovery::Parser do
     ]
   end
 
-  subject { described_class.new(api_response) }
-
   it "parses a target per resource" do
-    expect(subject.targets.size).to eq(3)
-    first, second, third = subject.targets
+    expect(parser.targets.size).to eq(3)
+    first, second, third = parser.targets
 
     expect(first.guid).to eq("app-1-guid")
     expect(first.name).to eq("app-1")

--- a/spec/cf_app_discovery/target_configuration_spec.rb
+++ b/spec/cf_app_discovery/target_configuration_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe CfAppDiscovery::TargetConfiguration do
   include StubHelper
 
-  subject do
+  subject(:target_configuration) do
     described_class.new(
       filestore_manager: LocalManager.new(targets_path: targets_path),
     )
@@ -45,7 +45,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
     end
 
     it "writes files named after the target guids" do
-      subject.write_active_targets(targets)
+      target_configuration.write_active_targets(targets)
 
       listing = Dir["#{targets_path}/active/*.json"]
       names = listing.map { |s| File.basename(s) }
@@ -54,7 +54,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
     end
 
     it "writes an entry per instance for each target" do
-      subject.write_active_targets(targets)
+      target_configuration.write_active_targets(targets)
 
       listing = Dir["#{targets_path}/active/*.json"]
       contents = listing.map { |path| File.read(path) }
@@ -106,7 +106,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
 
     context "when the target files already exist" do
       before do
-        subject.write_active_targets(targets)
+        target_configuration.write_active_targets(targets)
         @first, @second = Dir["#{targets_path}/active/*.json"]
 
         File.open(@first, "w") { |f| f.write("this content is out of date") }
@@ -116,16 +116,16 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
       end
 
       it "only writes files that have changed" do
-        subject.write_active_targets(targets)
+        target_configuration.write_active_targets(targets)
 
         expect(File.mtime(@first).to_i).not_to eq(0), "File should have been written"
         expect(File.mtime(@second).to_i).to eq(0), "File should not have been written"
       end
 
       it "lists the apps which have been configured" do
-        subject.write_active_targets(targets)
+        target_configuration.write_active_targets(targets)
 
-        configured_apps = subject.configured_apps
+        configured_apps = target_configuration.configured_apps
         expect(configured_apps.to_set).to contain_exactly('app-1-v2-guid', 'app-2-guid')
       end
     end
@@ -148,7 +148,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
     end
 
     it "writes an entry per instance for each target, without the space label" do
-      subject.write_active_targets(targets)
+      target_configuration.write_active_targets(targets)
 
       listing = Dir["#{targets_path}/active/*.json"]
       contents = listing.map { |path| File.read(path) }

--- a/spec/cf_app_discovery/target_updater_spec.rb
+++ b/spec/cf_app_discovery/target_updater_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CfAppDiscovery::TargetUpdater do
     FileUtils.touch("#{active_targets_path}/app-3-guid.json")
   end
 
-  subject do
+  subject(:target_updater) do
     described_class.new(
       filestore_manager: LocalManager.new(targets_path: targets_path, folders: %w(active inactive)),
       client: CfAppDiscovery::Client.new(
@@ -48,7 +48,7 @@ RSpec.describe CfAppDiscovery::TargetUpdater do
   end
 
   it "reads app instances from the API and writes to the targets directory" do
-    subject.run
+    target_updater.run
     names = filenames("#{active_targets_path}/*.json")
     expect(names).to contain_exactly('app-2-guid.json', 'app-3-guid.json')
 

--- a/spec/factories/target.rb
+++ b/spec/factories/target.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :target, :class => CfAppDiscovery::Target do
+  factory :target, class: CfAppDiscovery::Target do
     guid { nil }
     name { nil }
     instances { nil }
@@ -11,14 +11,14 @@ FactoryBot.define do
 
     initialize_with {
       new(
-        guid:guid,
-        name:name,
-        instances:instances,
-        state:state,
-        route:route,
-        space:space,
-        org:org,
-        detected_start_command:detected_start_command,
+        guid: guid,
+        name: name,
+        instances: instances,
+        state: state,
+        route: route,
+        space: space,
+        org: org,
+        detected_start_command: detected_start_command,
       )
     }
   end

--- a/spec/load_access_spec.rb
+++ b/spec/load_access_spec.rb
@@ -2,21 +2,23 @@ require "spec_helper"
 require_relative "../load_access"
 
 RSpec.describe "load_access" do
-  it 'returns correct contents' do
-    expect(get_creds).to eq("access_name" => "test-2")
+  describe "load_access is setup" do
+    it 'returns correct contents' do
+      expect(get_creds).to eq("access_name" => "test-2")
+    end
+
+    it 'does not raise an error' do
+      expect { get_creds }.not_to raise_error
+    end
   end
 
-  it 'does not raise an error' do
-    expect { get_creds }.not_to raise_error
-  end
-end
+  describe "load_access targets_access not setup" do
+    before {
+      ENV["VCAP_SERVICES"] = '{ "user-provided": [{ "name": "test-1", "credentials": {}}]}'
+    }
 
-RSpec.describe "load_access targets_access not setup" do
-  before {
-    ENV["VCAP_SERVICES"] = '{ "user-provided": [{ "name": "test-1", "credentials": {}}]}'
-  }
-
-  it 'raises an error' do
-    expect { get_creds }.to raise_error(RuntimeError, /The user-provided service has not been set up/)
+    it 'raises an error' do
+      expect { get_creds }.to raise_error(RuntimeError, /The user-provided service has not been set up/)
+    end
   end
 end


### PR DESCRIPTION
- We had no visibility of linting failures from new changes, because linting wasn't configured to run in CI. Instead, we relied (unreliably) on people remembering to run the whole `bundle exec rake` on their local machines, as we didn't have pre-commit hooks.
- This PR adds linting in diff mode, fixes all outstanding linting errors to tidy things up so we start from a clean slate, and disables some checks for "long specs" and the use of "and" in specs as these are common for this repo and we don't have time/priority for refactoring right now.

https://trello.com/c/AOY17SNd