### PR TITLE
Fix link to RE docs

### DIFF
--- a/lib/cf_app_discovery/service_broker.rb
+++ b/lib/cf_app_discovery/service_broker.rb
@@ -19,7 +19,7 @@ class CfAppDiscovery
           {
             id: settings.service_id,
             name: settings.service_name,
-            description: "GDS internal Prometheus monitoring beta https://reliability-engineering.cloudapps.digital/#metrics",
+            description: "GDS internal Prometheus monitoring beta https://reliability-engineering.cloudapps.digital",
             bindable: true,
             plans: [
               {


### PR DESCRIPTION
We provide a link in the service description for the GDS Prometheus
service broker. This link had broken recently as we changed our
section headings and the anchor no longer pointed to a existant
heading.

I could have fixed it to point at the new anchor for our section
but thought this may continue to change in the future so went
for the easiest long run approach on the assumption that once
users make it to the RE docs they will be able to find the content
about our service.