### PR TITLE
make target-updater log output much cleaner

### DIFF
--- a/bin/clock.rb
+++ b/bin/clock.rb
@@ -7,6 +7,6 @@ module Clockwork
   end
 
   every(60, 'Update targets') {
-    system("curl", "-d", "", "#{ENV.fetch('BROKER_ENDPOINT')}/update-targets")
+    system("curl", "-s", "-d", "", "#{ENV.fetch('BROKER_ENDPOINT')}/update-targets")
   }
 end


### PR DESCRIPTION
We were getting lots of noisy curl output in the logs.  The `-s` flag
suppresses it.