### PR TITLE
add __param_cf_app_instance service discovery param

### DIFF
--- a/lib/cf_app_discovery/target.rb
+++ b/lib/cf_app_discovery/target.rb
@@ -31,6 +31,7 @@ class CfAppDiscovery
           labels: {
             __param_cf_app_guid: guid,
             __param_cf_app_instance_index: index.to_s,
+            __param_cf_app_instance: instance(index),
             instance: instance(index),
             job: job,
             org: org,

--- a/spec/cf_app_discovery/target_configuration_spec.rb
+++ b/spec/cf_app_discovery/target_configuration_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v2-guid",
               __param_cf_app_instance_index: "0",
+              __param_cf_app_instance: "app-1-v2-guid:0",
               instance: "app-1-v2-guid:0",
               job: "app-1",
               space: "test-space-name",
@@ -78,6 +79,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v2-guid",
               __param_cf_app_instance_index: "1",
+              __param_cf_app_instance: "app-1-v2-guid:1",
               instance: "app-1-v2-guid:1",
               job: "app-1",
               space: "test-space-name",
@@ -91,6 +93,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-2-guid",
               __param_cf_app_instance_index: "0",
+              __param_cf_app_instance: "app-2-guid:0",
               instance: "app-2-guid:0",
               job: "app-2",
               space: "test-space-name",
@@ -168,6 +171,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v1-guid",
               __param_cf_app_instance_index: "0",
+              __param_cf_app_instance: "app-1-v1-guid:0",
               instance: "app-1-v1-guid:0",
               job: "app-1",
               org: "test-org-name",
@@ -178,6 +182,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v1-guid",
               __param_cf_app_instance_index: "1",
+              __param_cf_app_instance: "app-1-v1-guid:1",
               instance: "app-1-v1-guid:1",
               job: "app-1",
               org: "test-org-name",
@@ -190,6 +195,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-2-guid",
               __param_cf_app_instance_index: "0",
+              __param_cf_app_instance: "app-2-guid:0",
               instance: "app-2-guid:0",
               job: "app-2",
               org: "test-org-name",


### PR DESCRIPTION
This adds a new service discovery parameter, __param_cf_app_instance.
The idea is that, rather than passing separate parameters
`cf_app_guid` and `cf_app_instance_index` to the proxy server, which
then has to paste them together, we could just pass `cf_app_instance`
containing the header value exactly as required.

It's safe to pass extra parameters - they just get ignored.  This is
step one of a migration.