### PR TITLE
remove cf_app_instance label

### DIFF
--- a/lib/cf_app_discovery/target.rb
+++ b/lib/cf_app_discovery/target.rb
@@ -31,7 +31,6 @@ class CfAppDiscovery
           labels: {
             __param_cf_app_guid: guid,
             __param_cf_app_instance_index: index.to_s,
-            cf_app_instance: index.to_s,
             instance: instance(index),
             job: job,
             org: org,

--- a/spec/cf_app_discovery/target_configuration_spec.rb
+++ b/spec/cf_app_discovery/target_configuration_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v2-guid",
               __param_cf_app_instance_index: "0",
-              cf_app_instance: "0",
               instance: "app-1-v2-guid:0",
               job: "app-1",
               space: "test-space-name",
@@ -79,7 +78,6 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v2-guid",
               __param_cf_app_instance_index: "1",
-              cf_app_instance: "1",
               instance: "app-1-v2-guid:1",
               job: "app-1",
               space: "test-space-name",
@@ -93,7 +91,6 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-2-guid",
               __param_cf_app_instance_index: "0",
-              cf_app_instance: "0",
               instance: "app-2-guid:0",
               job: "app-2",
               space: "test-space-name",
@@ -171,7 +168,6 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v1-guid",
               __param_cf_app_instance_index: "0",
-              cf_app_instance: "0",
               instance: "app-1-v1-guid:0",
               job: "app-1",
               org: "test-org-name",
@@ -182,7 +178,6 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-1-v1-guid",
               __param_cf_app_instance_index: "1",
-              cf_app_instance: "1",
               instance: "app-1-v1-guid:1",
               job: "app-1",
               org: "test-org-name",
@@ -195,7 +190,6 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
             labels: {
               __param_cf_app_guid: "app-2-guid",
               __param_cf_app_instance_index: "0",
-              cf_app_instance: "0",
               instance: "app-2-guid:0",
               job: "app-2",
               org: "test-org-name",


### PR DESCRIPTION
This label isn't useful.  It's duplicated by the `instance` label,
meaning you always have to aggregate over both `instance` and
`cf_app_instance` in your `sum without(...)` queries.

I've checked and there are no problematic uses of cf_app_instance in
either our alerting rules or our grafana dashboards.  There are some
uses of `sum without (cf_app_instance...)...` but these queries will
continue to work even if the label disappears.