### PR TITLE
Reduce rate at which apps are discovered

### DIFF
--- a/bin/clock.rb
+++ b/bin/clock.rb
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 require 'clockwork'
 
+UPDATE_TARGETS_RATE_SECONDS = ENV.fetch('UPDATE_TARGETS_RATE_SECONDS', '120').to_i
+
+unless UPDATE_TARGETS_RATE_SECONDS >= 60
+  abort "UPDATE_TARGETS_RATE_SECONDS must be greater than or equal to 60, current value #{UPDATE_TARGETS_RATE_SECONDS}"
+end
+
 module Clockwork
   handler do |job|
     system(job)

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -19,6 +19,7 @@ defaults: &defaults
     SERVICE_NAME: gds-prometheus
     PLAN_ID: b5998c91-d379-4df7-b329-11450f8459f1
     CACHE_EXPIRY_TIME: 60
+    UPDATE_TARGETS_RATE_SECONDS: 180
 
 applications:
   - name: prometheus-service-broker

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -19,6 +19,7 @@ defaults: &defaults
     SERVICE_NAME: gds-prometheus-staging
     PLAN_ID: 01889e73-78b3-41d9-b29e-71d6ccfc8821
     CACHE_EXPIRY_TIME: 60
+    UPDATE_TARGETS_RATE_SECONDS: 180
 
 applications:
   - name: prometheus-service-broker-staging


### PR DESCRIPTION
This PR:

- sets a minimum clock rate of 60 seconds of the target-updater apps
- sets a default of 120 seconds of the target-updater apps
- configures the target-updater apps to scrape every 3 minutes (previously every minute)

User impact is: apps will be discovered more slowly (additional 2mins), this will become less of a problem as PaaS tenants start to use v3 endpoints (app guids will change less often).