### PR TITLE
Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -4,6 +4,7 @@ defaults: &defaults
     - ruby_buildpack
   memory: 512MB
   instances: 1
+  stack: cflinuxfs3
   services:
     - prometheus-targets-access
   env:

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -4,6 +4,7 @@ defaults: &defaults
     - ruby_buildpack
   memory: 512MB
   instances: 1
+  stack: cflinuxfs3
   services:
     - prometheus-targets-access-staging
   env:


### PR DESCRIPTION
- This is the Ubuntu Bionic stack as cflinuxfs2 (Ubuntu Trusty) goes out
of support soon.