### PR TITLE
filter internal domains out of routes

### DIFF
--- a/spec/cf_app_discovery/app_info_configurer_spec.rb
+++ b/spec/cf_app_discovery/app_info_configurer_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
       end
     end
 
-    context "when resources include private and public apps" do
-      it "uses the first available public app" do
+    context "when resources include private and public routes" do
+      it "uses the first available public route" do
         app_info_configurer.set_first_route(resource_with_private_and_public)
         expect(resource_with_private_and_public[:hostname]).to eq("public_host.sample_name.com")
         expect(resource_with_private_and_public[:path]).to eq("/sample_public_path")

--- a/spec/cf_app_discovery/app_info_configurer_spec.rb
+++ b/spec/cf_app_discovery/app_info_configurer_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
         "/v2/apps/sample_guid/routes" => {
           resources: [],
         },
+        "/v2/shared_domains" => {
+          resources: [{
+            metadata: {
+              url: "sample_private_domain_url"
+              },
+            entity: {
+              name: "apps.internal",
+              internal: true
+              }
+            }],
+        },
         "/v2/apps/sample_guid_with_host/routes" => {
           resources: [{
             entity: {
@@ -35,6 +46,24 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
             }
           }]
         },
+        "/v2/apps/sample_guid_with_private_and_public_resources/routes" => {
+          resources: [
+            {
+              entity: {
+                domain_url: "sample_private_domain_url",
+                host: "private_host",
+                path: "/sample_private_path"
+              }
+            },
+            {
+            entity: {
+              domain_url: "sample_domain_url",
+              host: "public_host",
+              path: "/sample_public_path"
+            }
+          }
+        ]
+        },
         "/v2/apps/sample_guid_without_host/routes" => {
           resources: [{
             entity: {
@@ -47,6 +76,15 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
         "sample_domain_url" => {
           entity: {
             name: "sample_name.com"
+          }
+        },
+        "sample_private_domain_url" => {
+          entity: {
+            name: "apps.internal",
+            internal: true
+          },
+          metadata: {
+            url: "sample_private_domain_url"
           }
         },
         "example_space.gov.uk" => {
@@ -132,6 +170,17 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
         }
       }
     }
+    let(:resource_with_private_and_public) {
+      {
+        metadata: {
+          guid: "sample_guid_with_private_and_public_resources"
+        },
+        entity: {
+          name: "app-name",
+          domain_url: "sample_domain_url"
+        }
+      }
+    }
 
     context "when resources field is nil" do
       it "sets a hostname on the input resource" do
@@ -170,6 +219,14 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
         app_info_configurer.set_first_route(resource_without_host)
         expect(resource_without_host[:hostname]).to eq("sample_name.com")
         expect(resource_without_host[:path]).to eq("")
+      end
+    end
+
+    context "when resources include private and public apps" do
+      it "uses the first available public app" do
+        app_info_configurer.set_first_route(resource_with_private_and_public)
+        expect(resource_with_private_and_public[:hostname]).to eq("public_host.sample_name.com")
+        expect(resource_with_private_and_public[:path]).to eq("/sample_public_path")
       end
     end
   end

--- a/spec/cf_app_discovery/service_broker_spec.rb
+++ b/spec/cf_app_discovery/service_broker_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe CfAppDiscovery::ServiceBroker do
   end
 
   before do
+    stub_endpoint(StubbableEndpoint::SharedDomains)
+    stub_endpoint(StubbableEndpoint::Auth)
     stub_endpoint(StubbableEndpoint::Auth)
     stub_endpoint(StubbableEndpoint::App)
     stub_endpoint(StubbableEndpoint::Domain1)

--- a/spec/cf_app_discovery/target_updater_spec.rb
+++ b/spec/cf_app_discovery/target_updater_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe CfAppDiscovery::TargetUpdater do
   end
 
   before do
+    stub_endpoint(StubbableEndpoint::SharedDomains)
     stub_endpoint(StubbableEndpoint::Apps)
     stub_endpoint(StubbableEndpoint::AppsPage2)
     stub_endpoint(StubbableEndpoint::Domain1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require "stubbable_endpoint/routes_2"
 require "stubbable_endpoint/routes_3"
 require "stubbable_endpoint/routes_4"
 require "stubbable_endpoint/space_1"
+require "stubbable_endpoint/shared_domains"
 require "local_manager"
 
 require 'rack/test'

--- a/spec/stubbable_endpoint/shared_domains.rb
+++ b/spec/stubbable_endpoint/shared_domains.rb
@@ -1,0 +1,34 @@
+module StubbableEndpoint
+  module SharedDomains
+    module_function
+
+    def http_method
+      :get
+    end
+
+    def url
+      "http://api.example.com/v2/shared_domains"
+    end
+
+    def request_headers
+      {
+        "Authorization" => "bearer dummy-oauth-token",
+        "User-Agent" => "cf_app_discovery - GDS - RE",
+      }
+    end
+
+    def request_body
+      ""
+    end
+
+    def response_headers
+      {}
+    end
+
+    def response_body
+      {
+        resources: []
+      }
+    end
+  end
+end


### PR DESCRIPTION
Previously, `cf_app_discovery` took no notice of the  [PaaS private apps functionality](https://docs.cloud.service.gov.uk/deploying_apps.html#deploying-private-apps) which may erroneously cause it to attempt to scrape the private internal domain, rather than any additional public domain which may contain a metrics endpoint.

This PR filters out any routes using domains marked as `internal: true` by querying `/v2/shared_domains` leaving only public routes suitable for scraping.

_Disclaimer: I do not work on this project or team, so please be gentle. 
Furthermore, I am unlikely to be able to respond to any feedback on this PR therefore I suggest the team review it and commit any changes as they see fit._