### PR TITLE
Fix bug with apps with only internal routes

### DIFF
--- a/lib/cf_app_discovery/app_info_configurer.rb
+++ b/lib/cf_app_discovery/app_info_configurer.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 class CfAppDiscovery
   class AppInfoConfigurer
     attr_reader :paas_domain
@@ -10,6 +12,7 @@ class CfAppDiscovery
         paas_domain: paas_domain
       )
       @paas_domain = paas_domain
+      @logger = Logger.new(STDOUT)
     end
 
     def apps
@@ -34,14 +37,15 @@ class CfAppDiscovery
 
     def set_first_route(resource)
       routes_data = @client.routes(resource.dig(:metadata, :guid)).fetch(:resources)
-      if routes_data.first.nil?
+      shared_domains_data = @client.get('/v2/shared_domains')
+      internal_domains = shared_domains_data[:resources].select { |r| r[:entity][:internal] }.map { |e| e[:metadata][:url] }
+      public_routes_data = routes_data.reject { |r| internal_domains.include?(r[:entity][:domain_url]) }
+      if public_routes_data.empty?
         app_name = resource.dig(:entity, :name)
+        @logger.warn("Couldn't find a public route for #{app_name}; guessing a route")
         resource[:hostname] = "#{app_name}.#{@paas_domain}"
         resource[:path] = ""
       else
-        shared_domains_data = @client.get('/v2/shared_domains')
-        internal_domains = shared_domains_data[:resources].select { |r| r[:entity][:internal] }.map { |e| e[:metadata][:url] }
-        public_routes_data = routes_data.reject { |r| internal_domains.include?(r[:entity][:domain_url]) }
         public_routes_metrics = public_routes_data.select { |r| r.dig(:entity, :path).end_with?('metrics') }
         chosen_public_route = if public_routes_metrics.empty?
                                 public_routes_data.first


### PR DESCRIPTION
This fixes a bug where an app which only had internal routes would not
be handled correctly.  Admittedly it's not clear what we *can* do if
there aren't any public routes but we should at least not cause
"undefined method dig for NilClass" exceptions.

We should also log when we're guessing a route because we're almost
certainly wrong.