### PR TITLE
Replace govuk-lint with rubocop-govuk gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.5.3
+  Exclude:
+    - 'vendor/**/*'
 
 Layout/AccessModifierIndentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ AllCops:
 
 Layout/AccessModifierIndentation:
   Enabled: false
+
+Style/StderrPuts:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,17 +5,5 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.5.3
 
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/DescribeClass:
-  Enabled: false
-
-RSpec/InstanceVariable:
-  Enabled: false
-
 Layout/AccessModifierIndentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
 
 AllCops:
   TargetRubyVersion: 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ rvm:
  - 2.5.3
 script:
   - bundle exec rspec
-  - bundle exec govuk-lint-ruby --diff
+  - bundle exec rubocop
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
  - 2.5.3
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
+before_install: # somehow travis isn't coming with bundler preinstalled any more?!
+  - gem install bundler -v '>= 2' || true
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
  - 2.5.3
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem "sinatra"
 
 group :development, :test do
   gem "factory_bot"
-  gem "govuk-lint"
   gem 'pry-byebug'
   gem 'rack-test', require: 'rack/test'
+  gem 'rubocop-govuk'
   gem "webmock"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '~> 2.5.1'
+ruby "~> 2.5.1"
 
 gem "aws-sdk-s3"
 gem "cf-uaa-lib"
@@ -16,8 +16,8 @@ gem "sinatra"
 
 group :development, :test do
   gem "factory_bot"
-  gem 'pry-byebug'
-  gem 'rack-test', require: 'rack/test'
-  gem 'rubocop-govuk'
+  gem "pry-byebug"
+  gem "rack-test", require: "rack/test"
+  gem "rubocop-govuk"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,24 +43,19 @@ GEM
     faraday-manual-cache (0.4.0)
       activesupport (>= 3.0.0)
       faraday (~> 0.9)
-    ffi (1.10.0)
-    govuk-lint (3.11.0)
-      rubocop (~> 0.64)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     hashdiff (0.3.8)
     httpclient (2.8.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.4)
     jmespath (1.4.0)
     method_source (0.9.2)
     minitest (5.11.3)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     mustermann (1.0.3)
-    parallel (1.15.0)
-    parser (2.6.2.0)
+    parallel (1.18.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     prometheus-client (0.9.0)
       quantile (~> 0.2.1)
@@ -70,7 +65,6 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    psych (3.1.0)
     public_suffix (3.0.3)
     quantile (0.2.1)
     rack (2.0.6)
@@ -80,9 +74,6 @@ GEM
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -96,26 +87,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.66.0)
+    rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      psych (>= 3.1.0)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-    rubocop-rspec (1.32.0)
-      rubocop (>= 0.60.0)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.3.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    rubocop-rspec (1.36.0)
+      rubocop (>= 0.68.1)
+    ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
-    sass (3.7.3)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.57.1)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
     sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -125,7 +114,7 @@ GEM
     tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.6.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -142,12 +131,12 @@ DEPENDENCIES
   factory_bot
   faraday
   faraday-manual-cache
-  govuk-lint
   prometheus-client
   pry-byebug
   rack-test
   rake
   rspec
+  rubocop-govuk
   sinatra
   webmock
 
@@ -155,4 +144,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :lint do
-  system("bundle exec govuk-lint-ruby")
+  system("bundle exec rubocop")
 end
 
 task default: %i[spec lint]

--- a/bin/clock.rb
+++ b/bin/clock.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
-require 'clockwork'
+require "clockwork"
 
-UPDATE_TARGETS_RATE_SECONDS = ENV.fetch('UPDATE_TARGETS_RATE_SECONDS', '120').to_i
+UPDATE_TARGETS_RATE_SECONDS = ENV.fetch("UPDATE_TARGETS_RATE_SECONDS", "120").to_i
 
 unless UPDATE_TARGETS_RATE_SECONDS >= 60
   abort "UPDATE_TARGETS_RATE_SECONDS must be greater than or equal to 60, current value #{UPDATE_TARGETS_RATE_SECONDS}"
@@ -12,7 +12,7 @@ module Clockwork
     system(job)
   end
 
-  every(60, 'Update targets') {
+  every(60, "Update targets") {
     system("curl", "-s", "-d", "", "#{ENV.fetch('BROKER_ENDPOINT')}/update-targets")
   }
 end

--- a/config.ru
+++ b/config.ru
@@ -1,13 +1,13 @@
-$LOAD_PATH.unshift('lib')
+$LOAD_PATH.unshift("lib")
 
-require 'rack'
-require 'prometheus/middleware/collector'
-require 'prometheus/middleware/exporter'
+require "rack"
+require "prometheus/middleware/collector"
+require "prometheus/middleware/exporter"
 
-require 'cf_app_discovery'
+require "cf_app_discovery"
 
 use Rack::Deflater
-use Prometheus::Middleware::Collector, metrics_prefix: 'observe_broker_http'
+use Prometheus::Middleware::Collector, metrics_prefix: "observe_broker_http"
 use Prometheus::Middleware::Exporter
 
 run CfAppDiscovery::ServiceBroker

--- a/lib/cf_app_discovery/app_info_configurer.rb
+++ b/lib/cf_app_discovery/app_info_configurer.rb
@@ -9,7 +9,7 @@ class CfAppDiscovery
       @client = CfClient.new(
         api_endpoint: api_endpoint,
         api_token: api_token,
-        paas_domain: paas_domain
+        paas_domain: paas_domain,
       )
       @paas_domain = paas_domain
       @logger = Logger.new(STDOUT)

--- a/lib/cf_app_discovery/app_info_configurer.rb
+++ b/lib/cf_app_discovery/app_info_configurer.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require "logger"
 
 class CfAppDiscovery
   class AppInfoConfigurer
@@ -37,7 +37,7 @@ class CfAppDiscovery
 
     def set_first_route(resource)
       routes_data = @client.routes(resource.dig(:metadata, :guid)).fetch(:resources)
-      shared_domains_data = @client.get('/v2/shared_domains')
+      shared_domains_data = @client.get("/v2/shared_domains")
       internal_domains = shared_domains_data[:resources].select { |r| r[:entity][:internal] }.map { |e| e[:metadata][:url] }
       public_routes_data = routes_data.reject { |r| internal_domains.include?(r[:entity][:domain_url]) }
       if public_routes_data.empty?
@@ -46,7 +46,7 @@ class CfAppDiscovery
         resource[:hostname] = "#{app_name}.#{@paas_domain}"
         resource[:path] = ""
       else
-        public_routes_metrics = public_routes_data.select { |r| r.dig(:entity, :path).end_with?('metrics') }
+        public_routes_metrics = public_routes_data.select { |r| r.dig(:entity, :path).end_with?("metrics") }
         chosen_public_route = if public_routes_metrics.empty?
                                 public_routes_data.first
                               else

--- a/lib/cf_app_discovery/cleaner.rb
+++ b/lib/cf_app_discovery/cleaner.rb
@@ -11,9 +11,9 @@ class CfAppDiscovery
     end
 
     def move_stopped_targets(stopped_targets)
-      target_files = filestore_manager.filenames('active')
+      target_files = filestore_manager.filenames("active")
       target_files.each do |filename|
-        filename = filename.split('/').last
+        filename = filename.split("/").last
         filestore_manager.move("active/#{filename}", "inactive/#{filename}") if file_in_targets?(filename, stopped_targets)
       end
     end

--- a/lib/cf_app_discovery/filestore_manager_factory.rb
+++ b/lib/cf_app_discovery/filestore_manager_factory.rb
@@ -1,7 +1,7 @@
 class CfAppDiscovery
   class FilestoreManagerFactory
     def self.filestore_manager_builder(environment, targets_path)
-      if environment.casecmp?('local')
+      if environment.casecmp?("local")
         LocalManager.new(targets_path: targets_path, folders: %w(active inactive))
       else
         S3Manager.new(bucket_name: ENV.fetch("BUCKET_NAME"))

--- a/lib/cf_app_discovery/parser.rb
+++ b/lib/cf_app_discovery/parser.rb
@@ -20,7 +20,7 @@ class CfAppDiscovery
           path: resource.fetch(:path),
           space: resource.fetch(:space),
           org: resource.fetch(:org),
-          detected_start_command: entity.fetch(:detected_start_command)
+          detected_start_command: entity.fetch(:detected_start_command),
         )
       end
     end

--- a/lib/cf_app_discovery/service_broker.rb
+++ b/lib/cf_app_discovery/service_broker.rb
@@ -29,7 +29,7 @@ class CfAppDiscovery
                 free: true,
               },
             ],
-          }
+          },
         ]
       )
     end

--- a/lib/cf_app_discovery/service_broker.rb
+++ b/lib/cf_app_discovery/service_broker.rb
@@ -30,7 +30,7 @@ class CfAppDiscovery
               },
             ],
           },
-        ]
+        ],
       )
     end
 
@@ -81,14 +81,14 @@ class CfAppDiscovery
     def target_updater
       @target_updater ||= TargetUpdater.new(
         filestore_manager: filestore_manager,
-        app_info_configurer: app_info_configurer
+        app_info_configurer: app_info_configurer,
       )
     end
 
     def filestore_manager
       @filestore_manager ||= FilestoreManagerFactory.filestore_manager_builder(
         settings.environment,
-        settings.targets_path
+        settings.targets_path,
       )
     end
 
@@ -101,7 +101,7 @@ class CfAppDiscovery
       @app_info_configurer ||= AppInfoConfigurer.new(
         api_endpoint: settings.api_endpoint,
         api_token: api_token,
-        paas_domain: settings.paas_domain
+        paas_domain: settings.paas_domain,
       )
     end
 

--- a/lib/cf_app_discovery/target.rb
+++ b/lib/cf_app_discovery/target.rb
@@ -57,7 +57,7 @@ class CfAppDiscovery
     def job
       # strip "-venerable" suffix from app names
       # so that autopilot deploys don't rename metrics
-      name.sub(/-venerable$/, '')
+      name.sub(/-venerable$/, "")
     end
   end
 end

--- a/lib/cf_app_discovery/target.rb
+++ b/lib/cf_app_discovery/target.rb
@@ -36,7 +36,7 @@ class CfAppDiscovery
             instance: instance(index),
             job: job,
             org: org,
-          }
+          },
         }
       unless paas_metric_exporter?
         data[:labels][:space] = space

--- a/lib/cf_app_discovery/target_configuration.rb
+++ b/lib/cf_app_discovery/target_configuration.rb
@@ -7,11 +7,11 @@ class CfAppDiscovery
     end
 
     def write_active_targets(targets)
-      write_targets(targets, 'active')
+      write_targets(targets, "active")
     end
 
     def write_inactive_targets(targets)
-      write_targets(targets, 'inactive')
+      write_targets(targets, "inactive")
     end
 
     def configured_apps

--- a/lib/cf_app_discovery/target_updater.rb
+++ b/lib/cf_app_discovery/target_updater.rb
@@ -18,7 +18,7 @@ class CfAppDiscovery
 
       configured_targets = filter.filter_prometheus_available(
         targets,
-        target_configuration.configured_apps
+        target_configuration.configured_apps,
       )
       running_targets = filter.filter_stopped(configured_targets)
       stopped_targets = configured_targets - running_targets

--- a/load_access.rb
+++ b/load_access.rb
@@ -7,11 +7,11 @@ def get_creds
   vcap_services = JSON.parse(json)
   user_provided = vcap_services.fetch("user-provided")
   prometheus_access = user_provided.find { |e| e["credentials"].key?("access_name") }
-  targets_access_name = prometheus_access['credentials']['access_name'] unless not prometheus_access
+  targets_access_name = prometheus_access["credentials"]["access_name"] unless not prometheus_access
 
   raise "The user-provided service has not been set up." unless prometheus_access && prometheus_access["name"] == targets_access_name
 
-  prometheus_access['credentials']
+  prometheus_access["credentials"]
 end
 
 if $0 == __FILE__

--- a/load_access.rb
+++ b/load_access.rb
@@ -7,7 +7,7 @@ def get_creds
   vcap_services = JSON.parse(json)
   user_provided = vcap_services.fetch("user-provided")
   prometheus_access = user_provided.find { |e| e["credentials"].key?("access_name") }
-  targets_access_name = prometheus_access["credentials"]["access_name"] unless not prometheus_access
+  targets_access_name = prometheus_access["credentials"]["access_name"] if prometheus_access
 
   raise "The user-provided service has not been set up." unless prometheus_access && prometheus_access["name"] == targets_access_name
 

--- a/spec/cf_app_discovery/app_info_configurer_spec.rb
+++ b/spec/cf_app_discovery/app_info_configurer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
                 host: "public_host",
                 path: "/sample_public_path",
               },
-            }
+            },
           ],
         },
         "/v2/apps/sample_guid_with_metrics_and_nonmetrics_resources/routes" => {
@@ -79,7 +79,7 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
                 host: "public_host",
                 path: "/sample_public_path/metrics",
               },
-            }
+            },
           ],
         },
         "/v2/apps/sample_guid_without_host/routes" => {

--- a/spec/cf_app_discovery/app_info_configurer_spec.rb
+++ b/spec/cf_app_discovery/app_info_configurer_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
         "/v2/shared_domains" => {
           resources: [{
             metadata: {
-              url: "sample_private_domain_url"
+              url: "sample_private_domain_url",
               },
             entity: {
               name: "apps.internal",
-              internal: true
-              }
+              internal: true,
+              },
             }],
         },
         "/v2/apps/sample_guid_with_host/routes" => {
@@ -24,27 +24,27 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
             entity: {
               domain_url: "sample_domain_url",
               host: "sample_host",
-              path: ""
-            }
-          }]
+              path: "",
+            },
+          }],
         },
         "/v2/apps/sample_guid_with_path/routes" => {
           resources: [{
             entity: {
               domain_url: "sample_domain_url",
               host: "",
-              path: "/sample_path"
-            }
-          }]
+              path: "/sample_path",
+            },
+          }],
         },
         "/v2/apps/sample_guid_with_host_and_path/routes" => {
           resources: [{
             entity: {
               domain_url: "sample_domain_url",
               host: "sample_host",
-              path: "/sample_path"
-            }
-          }]
+              path: "/sample_path",
+            },
+          }],
         },
         "/v2/apps/sample_guid_with_private_and_public_resources/routes" => {
           resources: [
@@ -52,17 +52,17 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
               entity: {
                 domain_url: "sample_private_domain_url",
                 host: "private_host",
-                path: "/sample_private_path"
-              }
+                path: "/sample_private_path",
+              },
             },
             {
               entity: {
                 domain_url: "sample_domain_url",
                 host: "public_host",
-                path: "/sample_public_path"
-              }
+                path: "/sample_public_path",
+              },
             }
-          ]
+          ],
         },
         "/v2/apps/sample_guid_with_metrics_and_nonmetrics_resources/routes" => {
           resources: [
@@ -70,52 +70,52 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
               entity: {
                 domain_url: "sample_domain_url",
                 host: "public_host",
-                path: "/sample_public_path"
-              }
+                path: "/sample_public_path",
+              },
             },
             {
               entity: {
                 domain_url: "sample_domain_url",
                 host: "public_host",
-                path: "/sample_public_path/metrics"
-              }
+                path: "/sample_public_path/metrics",
+              },
             }
-          ]
+          ],
         },
         "/v2/apps/sample_guid_without_host/routes" => {
           resources: [{
             entity: {
               domain_url: "sample_domain_url",
               host: "",
-              path: ""
-            }
-          }]
+              path: "",
+            },
+          }],
         },
         "sample_domain_url" => {
           entity: {
-            name: "sample_name.com"
-          }
+            name: "sample_name.com",
+          },
         },
         "sample_private_domain_url" => {
           entity: {
             name: "apps.internal",
-            internal: true
+            internal: true,
           },
           metadata: {
-            url: "sample_private_domain_url"
-          }
+            url: "sample_private_domain_url",
+          },
         },
         "example_space.gov.uk" => {
           entity: {
             name: "example_space_name",
-            organization_url: "example_org.gov.uk"
-          }
+            organization_url: "example_org.gov.uk",
+          },
         },
         "example_org.gov.uk" => {
           entity: {
-            name: "example_org_name"
-          }
-        }
+            name: "example_org_name",
+          },
+        },
       }
       path_hash[path]
     end
@@ -141,72 +141,72 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
     let(:resource) {
       {
         metadata: {
-          guid: "sample_guid"
+          guid: "sample_guid",
         },
         entity: {
-          name: "test_name"
-        }
+          name: "test_name",
+        },
       }
     }
     let(:resource_with_host) {
       {
         metadata: {
-          guid: "sample_guid_with_host"
+          guid: "sample_guid_with_host",
         },
         entity: {
-          domain_url: "sample_domain_url"
-        }
+          domain_url: "sample_domain_url",
+        },
       }
     }
     let(:resource_with_path) {
       {
         metadata: {
-          guid: "sample_guid_with_path"
+          guid: "sample_guid_with_path",
         },
         entity: {
-          domain_url: "sample_domain_url"
-        }
+          domain_url: "sample_domain_url",
+        },
       }
     }
     let(:resource_with_host_and_path) {
       {
         metadata: {
-          guid: "sample_guid_with_host_and_path"
+          guid: "sample_guid_with_host_and_path",
         },
         entity: {
-          domain_url: "sample_domain_url"
-        }
+          domain_url: "sample_domain_url",
+        },
       }
     }
     let(:resource_with_host_and_path_metrics_and_nonmetrics) {
       {
         metadata: {
-          guid: "sample_guid_with_metrics_and_nonmetrics_resources"
+          guid: "sample_guid_with_metrics_and_nonmetrics_resources",
         },
         entity: {
-          domain_url: "sample_domain_url"
-        }
+          domain_url: "sample_domain_url",
+        },
       }
     }
     let(:resource_without_host) {
       {
         metadata: {
-          guid: "sample_guid_without_host"
+          guid: "sample_guid_without_host",
         },
         entity: {
-          domain_url: "sample_domain_url"
-        }
+          domain_url: "sample_domain_url",
+        },
       }
     }
     let(:resource_with_private_and_public) {
       {
         metadata: {
-          guid: "sample_guid_with_private_and_public_resources"
+          guid: "sample_guid_with_private_and_public_resources",
         },
         entity: {
           name: "app-name",
-          domain_url: "sample_domain_url"
-        }
+          domain_url: "sample_domain_url",
+        },
       }
     }
 
@@ -270,8 +270,8 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
     let(:resource_org_and_space) {
       {
         entity: {
-        space_url: "example_space.gov.uk"
-        }
+        space_url: "example_space.gov.uk",
+        },
       }
     }
 

--- a/spec/cf_app_discovery/app_info_configurer_spec.rb
+++ b/spec/cf_app_discovery/app_info_configurer_spec.rb
@@ -1,4 +1,4 @@
-require 'json'
+require "json"
 require "spec_helper"
 
 RSpec.describe CfAppDiscovery::AppInfoConfigurer do

--- a/spec/cf_app_discovery/app_info_configurer_spec.rb
+++ b/spec/cf_app_discovery/app_info_configurer_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe CfAppDiscovery::AppInfoConfigurer do
     described_class.new(
       api_endpoint: "http://api.example.com",
       api_token: "dummy-oauth-token",
-      paas_domain: "example.com"
+      paas_domain: "example.com",
     )
   end
 

--- a/spec/cf_app_discovery/cf_client_spec.rb
+++ b/spec/cf_app_discovery/cf_client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CfAppDiscovery::CfClient do
     described_class.new(
       api_endpoint: "http://api.example.com",
       api_token: "dummy-oauth-token",
-      paas_domain: "example.com"
+      paas_domain: "example.com",
     )
   end
 

--- a/spec/cf_app_discovery/cf_client_spec.rb
+++ b/spec/cf_app_discovery/cf_client_spec.rb
@@ -1,4 +1,4 @@
-require 'json'
+require "json"
 require "spec_helper"
 
 RSpec.describe CfAppDiscovery::CfClient do

--- a/spec/cf_app_discovery/cleaner_spec.rb
+++ b/spec/cf_app_discovery/cleaner_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe CfAppDiscovery::Cleaner do
   subject(:cleaner) do
     described_class.new(
-      filestore_manager: LocalManager.new(targets_path: targets_path, folders: %w(active inactive))
+      filestore_manager: LocalManager.new(targets_path: targets_path, folders: %w(active inactive)),
     )
   end
 

--- a/spec/cf_app_discovery/filter_spec.rb
+++ b/spec/cf_app_discovery/filter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CfAppDiscovery::Filter do
       build(:target,
             guid: 'app-3-guid',
             name: 'app-3',
-            state: 'STARTED')
+            state: 'STARTED'),
     ]
   end
 

--- a/spec/cf_app_discovery/filter_spec.rb
+++ b/spec/cf_app_discovery/filter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CfAppDiscovery::Filter do
         :target,
         guid: "app-1-guid",
         name: "app-1",
-        state: "STARTED"
+        state: "STARTED",
       ),
       build(:target,
             guid: "app-2-guid",

--- a/spec/cf_app_discovery/filter_spec.rb
+++ b/spec/cf_app_discovery/filter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe CfAppDiscovery::Filter do
   subject(:filter) { described_class.new }
@@ -9,26 +9,26 @@ RSpec.describe CfAppDiscovery::Filter do
     [
       build(
         :target,
-        guid: 'app-1-guid',
-        name: 'app-1',
-        state: 'STARTED'
+        guid: "app-1-guid",
+        name: "app-1",
+        state: "STARTED"
       ),
       build(:target,
-            guid: 'app-2-guid',
-            name: 'app-2',
-            state: 'STOPPED'),
+            guid: "app-2-guid",
+            name: "app-2",
+            state: "STOPPED"),
       build(:target,
-            guid: 'app-3-guid',
-            name: 'app-3',
-            state: 'STARTED'),
+            guid: "app-3-guid",
+            name: "app-3",
+            state: "STARTED"),
     ]
   end
 
-  it 'filters target not running' do
+  it "filters target not running" do
     expect(filter.filter_stopped(targets)).to eq [targets.first, targets.last]
   end
 
-  it 'filters target based on given app guids' do
-    expect(filter.filter_prometheus_available(targets, ['app-3-guid'])).to eq [targets.last]
+  it "filters target based on given app guids" do
+    expect(filter.filter_prometheus_available(targets, ["app-3-guid"])).to eq [targets.last]
   end
 end

--- a/spec/cf_app_discovery/parser_spec.rb
+++ b/spec/cf_app_discovery/parser_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CfAppDiscovery::Parser do
           name: "app-2",
           instances: 3,
           state: "STOPPED",
-          detected_start_command: "$HOME/boot.sh"
+          detected_start_command: "$HOME/boot.sh",
         },
         hostname: "route-2",
         path: "",
@@ -41,7 +41,7 @@ RSpec.describe CfAppDiscovery::Parser do
           name: "app-3",
           instances: 2,
           state: "STARTED",
-          detected_start_command: ""
+          detected_start_command: "",
         },
         hostname: "route-3",
         path: "",

--- a/spec/cf_app_discovery/service_broker_spec.rb
+++ b/spec/cf_app_discovery/service_broker_spec.rb
@@ -36,27 +36,27 @@ RSpec.describe CfAppDiscovery::ServiceBroker do
       it "returns a 200 response" do
         expect(last_response.status).to eq(200)
         body = JSON.parse(last_response.body, symbolize_names: true)
-        expect(body.fetch(:services)[0].fetch(:id)).to eq('fd609087-70e0-4c8c-8916-b6885ac156a3')
+        expect(body.fetch(:services)[0].fetch(:id)).to eq("fd609087-70e0-4c8c-8916-b6885ac156a3")
       end
     end
   end
 
   describe "put /v2/service_instances/:id" do
     before do
-      put '/v2/service_instances/:id'
+      put "/v2/service_instances/:id"
     end
 
-    it 'return a 200 response' do
+    it "return a 200 response" do
       expect(last_response.status).to eq(200)
     end
   end
 
   describe "/v2/service_instances/:instance_id/service_bindings/:id" do
     before do
-      put '/v2/service_instances/:instance_id/service_bindings/:id', api_request
+      put "/v2/service_instances/:instance_id/service_bindings/:id", api_request
     end
 
-    it 'return a 200 response' do
+    it "return a 200 response" do
       expect(last_response.status).to eq(200)
     end
   end
@@ -66,7 +66,7 @@ RSpec.describe CfAppDiscovery::ServiceBroker do
       delete "/v2/service_instances/:instance_id/service_bindings/:id", api_request
     end
 
-    it 'return a 200 response' do
+    it "return a 200 response" do
       expect(last_response.status).to eq(200)
     end
   end

--- a/spec/cf_app_discovery/target_configuration_spec.rb
+++ b/spec/cf_app_discovery/target_configuration_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
       listing = Dir["#{targets_path}/active/*.json"]
       names = listing.map { |s| File.basename(s) }
 
-      expect(names).to contain_exactly('app-1-v2-guid.json', 'app-2-guid.json')
+      expect(names).to contain_exactly("app-1-v2-guid.json", "app-2-guid.json")
     end
 
     it "writes an entry per instance for each target" do
@@ -131,7 +131,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
         target_configuration.write_active_targets(targets)
 
         configured_apps = target_configuration.configured_apps
-        expect(configured_apps.to_set).to contain_exactly('app-1-v2-guid', 'app-2-guid')
+        expect(configured_apps.to_set).to contain_exactly("app-1-v2-guid", "app-2-guid")
       end
     end
   end

--- a/spec/cf_app_discovery/target_configuration_spec.rb
+++ b/spec/cf_app_discovery/target_configuration_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
               org: "test-org-name",
             },
           },
-        ]
+        ],
       )
     end
 
@@ -210,7 +210,7 @@ RSpec.describe CfAppDiscovery::TargetConfiguration do
               org: "test-org-name",
             },
           },
-        ]
+        ],
       )
     end
   end

--- a/spec/cf_app_discovery/target_updater_spec.rb
+++ b/spec/cf_app_discovery/target_updater_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe CfAppDiscovery::TargetUpdater do
   it "reads app instances from the API and writes to the targets directory" do
     target_updater.run
     names = filenames("#{active_targets_path}/*.json")
-    expect(names).to contain_exactly('app-2-guid.json', 'app-3-guid.json')
+    expect(names).to contain_exactly("app-2-guid.json", "app-3-guid.json")
 
     names = filenames("#{inactive_targets_path}/*.json")
-    expect(names).to contain_exactly('app-1-guid.json', 'app-2-guid.json')
+    expect(names).to contain_exactly("app-1-guid.json", "app-2-guid.json")
   end
 
   def filenames(path)

--- a/spec/cf_app_discovery/target_updater_spec.rb
+++ b/spec/cf_app_discovery/target_updater_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CfAppDiscovery::TargetUpdater do
       app_info_configurer: CfAppDiscovery::AppInfoConfigurer.new(
         api_endpoint: "http://api.example.com",
         api_token: "dummy-oauth-token",
-        paas_domain: "example.com"
-      )
+        paas_domain: "example.com",
+      ),
     )
   end
 

--- a/spec/load_access_spec.rb
+++ b/spec/load_access_spec.rb
@@ -3,11 +3,11 @@ require_relative "../load_access"
 
 RSpec.describe "load_access" do
   describe "load_access is setup" do
-    it 'returns correct contents' do
+    it "returns correct contents" do
       expect(get_creds).to eq("access_name" => "test-2")
     end
 
-    it 'does not raise an error' do
+    it "does not raise an error" do
       expect { get_creds }.not_to raise_error
     end
   end
@@ -17,7 +17,7 @@ RSpec.describe "load_access" do
       ENV["VCAP_SERVICES"] = '{ "user-provided": [{ "name": "test-1", "credentials": {}}]}'
     }
 
-    it 'raises an error' do
+    it "raises an error" do
       expect { get_creds }.to raise_error(RuntimeError, /The user-provided service has not been set up/)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,20 +23,20 @@ require "stubbable_endpoint/space_1"
 require "stubbable_endpoint/shared_domains"
 require "local_manager"
 
-require 'rack/test'
+require "rack/test"
 
-ENV["API_ENDPOINT"] = 'http://api.example.com'
-ENV["UAA_ENDPOINT"] = 'http://uaa.example.com'
-ENV["UAA_USERNAME"] = 'uaa-username'
-ENV["UAA_PASSWORD"] = 'uaa-password'
-ENV["PAAS_DOMAIN"] = 'example.com'
+ENV["API_ENDPOINT"] = "http://api.example.com"
+ENV["UAA_ENDPOINT"] = "http://uaa.example.com"
+ENV["UAA_USERNAME"] = "uaa-username"
+ENV["UAA_PASSWORD"] = "uaa-password"
+ENV["PAAS_DOMAIN"] = "example.com"
 ENV["TARGETS_PATH"] = Dir.mktmpdir
-ENV["ENVIRONMENT"] = 'local'
-ENV["SERVICE_ID"] = 'fd609087-70e0-4c8c-8916-b6885ac156a3'
-ENV["SERVICE_NAME"] = 'gds-prometheus-test'
-ENV["PLAN_ID"] = 'b5998c91-d379-4df7-b329-11450f8459f1'
+ENV["ENVIRONMENT"] = "local"
+ENV["SERVICE_ID"] = "fd609087-70e0-4c8c-8916-b6885ac156a3"
+ENV["SERVICE_NAME"] = "gds-prometheus-test"
+ENV["PLAN_ID"] = "b5998c91-d379-4df7-b329-11450f8459f1"
 ENV["VCAP_SERVICES"] = '{ "user-provided": [{ "name": "test-1", "credentials": {}}, { "name": "test-2", "credentials": {"access_name": "test-2"}}]}'
-ENV["CACHE_EXPIRY_TIME"] = '1'
+ENV["CACHE_EXPIRY_TIME"] = "1"
 
 require "cf_app_discovery"
 

--- a/spec/stub_helper.rb
+++ b/spec/stub_helper.rb
@@ -8,7 +8,7 @@ module StubHelper
       .to_return(
         body: endpoint.response_body.to_json,
         headers: endpoint.response_headers,
-        status: status
+        status: status,
       )
   end
 end

--- a/spec/stubbable_endpoint/apps.rb
+++ b/spec/stubbable_endpoint/apps.rb
@@ -51,7 +51,7 @@ module StubbableEndpoint
               detected_start_command: './bin/paas-metric-exporter',
               space_url: '/v2/spaces/example-space-guid',
             },
-          }
+          },
         ],
       }
     end

--- a/spec/stubbable_endpoint/apps.rb
+++ b/spec/stubbable_endpoint/apps.rb
@@ -15,7 +15,7 @@ module StubbableEndpoint
     def request_headers
       {
         'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE'
+        'User-Agent' => 'cf_app_discovery - GDS - RE',
       }
     end
 
@@ -39,8 +39,8 @@ module StubbableEndpoint
               instances: 2,
               state: 'STOPPED',
               detected_start_command: nil,
-              space_url: '/v2/spaces/example-space-guid'
-            }
+              space_url: '/v2/spaces/example-space-guid',
+            },
           },
           {
             metadata: { guid: 'app-2-guid' },
@@ -49,10 +49,10 @@ module StubbableEndpoint
               instances: 2,
               state: 'STARTED',
               detected_start_command: './bin/paas-metric-exporter',
-              space_url: '/v2/spaces/example-space-guid'
-            }
+              space_url: '/v2/spaces/example-space-guid',
+            },
           }
-        ]
+        ],
       }
     end
   end

--- a/spec/stubbable_endpoint/apps.rb
+++ b/spec/stubbable_endpoint/apps.rb
@@ -9,18 +9,18 @@ module StubbableEndpoint
     end
 
     def url
-      'http://api.example.com/v2/apps'
+      "http://api.example.com/v2/apps"
     end
 
     def request_headers
       {
-        'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE',
+        "Authorization" => "bearer dummy-oauth-token",
+        "User-Agent" => "cf_app_discovery - GDS - RE",
       }
     end
 
     def request_body
-      ''
+      ""
     end
 
     def response_headers
@@ -29,27 +29,27 @@ module StubbableEndpoint
 
     def response_body
       {
-        next_url: '/v2/apps?page=2',
+        next_url: "/v2/apps?page=2",
         prev_url: nil,
         resources: [
           {
-            metadata: { guid: 'app-1-guid' },
+            metadata: { guid: "app-1-guid" },
             entity: {
-              name: 'app-1',
+              name: "app-1",
               instances: 2,
-              state: 'STOPPED',
+              state: "STOPPED",
               detected_start_command: nil,
-              space_url: '/v2/spaces/example-space-guid',
+              space_url: "/v2/spaces/example-space-guid",
             },
           },
           {
-            metadata: { guid: 'app-2-guid' },
+            metadata: { guid: "app-2-guid" },
             entity: {
-              name: 'app-2',
+              name: "app-2",
               instances: 2,
-              state: 'STARTED',
-              detected_start_command: './bin/paas-metric-exporter',
-              space_url: '/v2/spaces/example-space-guid',
+              state: "STARTED",
+              detected_start_command: "./bin/paas-metric-exporter",
+              space_url: "/v2/spaces/example-space-guid",
             },
           },
         ],

--- a/spec/stubbable_endpoint/apps_page_2.rb
+++ b/spec/stubbable_endpoint/apps_page_2.rb
@@ -47,7 +47,7 @@ module StubbableEndpoint
               space_url: "/v2/spaces/example-space-guid",
             },
           },
-        ]
+        ],
       }
     end
   end

--- a/spec/stubbable_endpoint/auth.rb
+++ b/spec/stubbable_endpoint/auth.rb
@@ -32,7 +32,7 @@ module StubbableEndpoint
     def response_body
       {
         access_token: 'dummy-oauth-token',
-        token_type: 'bearer'
+        token_type: 'bearer',
       }
     end
   end

--- a/spec/stubbable_endpoint/auth.rb
+++ b/spec/stubbable_endpoint/auth.rb
@@ -9,30 +9,30 @@ module StubbableEndpoint
     end
 
     def url
-      'http://uaa.example.com/oauth/token'
+      "http://uaa.example.com/oauth/token"
     end
 
     def request_headers
-      { 'Authorization' => 'Basic Y2Y6' }
+      { "Authorization" => "Basic Y2Y6" }
     end
 
     def request_body
       URI.encode_www_form(
-        grant_type: 'password',
-        username: 'uaa-username',
-        password: 'uaa-password',
-        scope: 'cloud_controller.read'
+        grant_type: "password",
+        username: "uaa-username",
+        password: "uaa-password",
+        scope: "cloud_controller.read"
       )
     end
 
     def response_headers
-      { 'Content-Type' => 'application/json' }
+      { "Content-Type" => "application/json" }
     end
 
     def response_body
       {
-        access_token: 'dummy-oauth-token',
-        token_type: 'bearer',
+        access_token: "dummy-oauth-token",
+        token_type: "bearer",
       }
     end
   end

--- a/spec/stubbable_endpoint/auth.rb
+++ b/spec/stubbable_endpoint/auth.rb
@@ -21,7 +21,7 @@ module StubbableEndpoint
         grant_type: "password",
         username: "uaa-username",
         password: "uaa-password",
-        scope: "cloud_controller.read"
+        scope: "cloud_controller.read",
       )
     end
 

--- a/spec/stubbable_endpoint/domain_1.rb
+++ b/spec/stubbable_endpoint/domain_1.rb
@@ -29,7 +29,7 @@ module StubbableEndpoint
       {
           entity: {
               name: "example.com",
-          }
+          },
       }
     end
   end

--- a/spec/stubbable_endpoint/domain_2.rb
+++ b/spec/stubbable_endpoint/domain_2.rb
@@ -29,7 +29,7 @@ module StubbableEndpoint
       {
           entity: {
               name: "custom-domain.gov.uk",
-          }
+          },
       }
     end
   end

--- a/spec/stubbable_endpoint/get.rb
+++ b/spec/stubbable_endpoint/get.rb
@@ -28,7 +28,7 @@ module StubbableEndpoint
     def response_body
       {
         metadata: {},
-        entity: {}
+        entity: {},
       }
     end
   end

--- a/spec/stubbable_endpoint/get_forbidden.rb
+++ b/spec/stubbable_endpoint/get_forbidden.rb
@@ -29,7 +29,7 @@ module StubbableEndpoint
       {
           description: "You are not authorized to perform the requested action",
           error_code: "CF-NotAuthorized",
-          code: 10003
+          code: 10003,
       }
     end
   end

--- a/spec/stubbable_endpoint/get_not_found.rb
+++ b/spec/stubbable_endpoint/get_not_found.rb
@@ -13,7 +13,7 @@ module StubbableEndpoint
     def request_headers
       {
           "Authorization" => "bearer dummy-oauth-token",
-          "User-Agent" => "cf_app_discovery - GDS - RE"
+          "User-Agent" => "cf_app_discovery - GDS - RE",
       }
     end
 
@@ -29,7 +29,7 @@ module StubbableEndpoint
       {
           description: "The app could not be found: not-found",
           error_code: "CF-AppNotFound",
-          code: 100004
+          code: 100004,
       }
     end
   end

--- a/spec/stubbable_endpoint/org_1.rb
+++ b/spec/stubbable_endpoint/org_1.rb
@@ -29,7 +29,7 @@ module StubbableEndpoint
       {
           entity: {
             name: "org-name",
-          }
+          },
       }
     end
   end

--- a/spec/stubbable_endpoint/routes_1.rb
+++ b/spec/stubbable_endpoint/routes_1.rb
@@ -33,16 +33,16 @@ module StubbableEndpoint
                       domain_url: "/v2/shared_domains/domain-guid",
                       host: "route-1a",
                       path: "",
-                  }
+                  },
               },
               {
                   entity: {
                       domain_url: "/v2/shared_domains/domain-guid",
                       host: "route-1b",
                       path: "",
-                  }
+                  },
               },
-          ]
+          ],
       }
     end
   end

--- a/spec/stubbable_endpoint/routes_2.rb
+++ b/spec/stubbable_endpoint/routes_2.rb
@@ -9,18 +9,18 @@ module StubbableEndpoint
     end
 
     def url
-      'http://api.example.com/v2/apps/app-2-guid/routes'
+      "http://api.example.com/v2/apps/app-2-guid/routes"
     end
 
     def request_headers
       {
-        'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE',
+        "Authorization" => "bearer dummy-oauth-token",
+        "User-Agent" => "cf_app_discovery - GDS - RE",
       }
     end
 
     def request_body
-      ''
+      ""
     end
 
     def response_headers
@@ -32,16 +32,16 @@ module StubbableEndpoint
         resources: [
           {
             entity: {
-              domain_url: '/v2/shared_domains/domain-guid',
-              host: 'route-2a',
-              path: '',
+              domain_url: "/v2/shared_domains/domain-guid",
+              host: "route-2a",
+              path: "",
             },
           },
           {
             entity: {
-              domain_url: '/v2/shared_domains/domain-guid',
-              host: 'route-2b',
-              path: '',
+              domain_url: "/v2/shared_domains/domain-guid",
+              host: "route-2b",
+              path: "",
             },
           },
         ],

--- a/spec/stubbable_endpoint/routes_2.rb
+++ b/spec/stubbable_endpoint/routes_2.rb
@@ -43,7 +43,7 @@ module StubbableEndpoint
               host: 'route-2b',
               path: '',
             },
-          }
+          },
         ],
       }
     end

--- a/spec/stubbable_endpoint/routes_2.rb
+++ b/spec/stubbable_endpoint/routes_2.rb
@@ -15,7 +15,7 @@ module StubbableEndpoint
     def request_headers
       {
         'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE'
+        'User-Agent' => 'cf_app_discovery - GDS - RE',
       }
     end
 
@@ -34,17 +34,17 @@ module StubbableEndpoint
             entity: {
               domain_url: '/v2/shared_domains/domain-guid',
               host: 'route-2a',
-              path: ''
-            }
+              path: '',
+            },
           },
           {
             entity: {
               domain_url: '/v2/shared_domains/domain-guid',
               host: 'route-2b',
-              path: ''
-            }
+              path: '',
+            },
           }
-        ]
+        ],
       }
     end
   end

--- a/spec/stubbable_endpoint/routes_3.rb
+++ b/spec/stubbable_endpoint/routes_3.rb
@@ -9,18 +9,18 @@ module StubbableEndpoint
     end
 
     def url
-      'http://api.example.com/v2/apps/app-3-guid/routes'
+      "http://api.example.com/v2/apps/app-3-guid/routes"
     end
 
     def request_headers
       {
-        'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE',
+        "Authorization" => "bearer dummy-oauth-token",
+        "User-Agent" => "cf_app_discovery - GDS - RE",
       }
     end
 
     def request_body
-      ''
+      ""
     end
 
     def response_headers
@@ -32,9 +32,9 @@ module StubbableEndpoint
         resources: [
           {
             entity: {
-              domain_url: '/v2/shared_domains/custom-domain-guid',
-              host: '',
-              path: '',
+              domain_url: "/v2/shared_domains/custom-domain-guid",
+              host: "",
+              path: "",
             },
           },
         ],

--- a/spec/stubbable_endpoint/routes_3.rb
+++ b/spec/stubbable_endpoint/routes_3.rb
@@ -36,7 +36,7 @@ module StubbableEndpoint
               host: '',
               path: '',
             },
-          }
+          },
         ],
       }
     end

--- a/spec/stubbable_endpoint/routes_3.rb
+++ b/spec/stubbable_endpoint/routes_3.rb
@@ -15,7 +15,7 @@ module StubbableEndpoint
     def request_headers
       {
         'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE'
+        'User-Agent' => 'cf_app_discovery - GDS - RE',
       }
     end
 
@@ -34,10 +34,10 @@ module StubbableEndpoint
             entity: {
               domain_url: '/v2/shared_domains/custom-domain-guid',
               host: '',
-              path: ''
-            }
+              path: '',
+            },
           }
-        ]
+        ],
       }
     end
   end

--- a/spec/stubbable_endpoint/routes_4.rb
+++ b/spec/stubbable_endpoint/routes_4.rb
@@ -15,7 +15,7 @@ module StubbableEndpoint
     def request_headers
       {
         'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE'
+        'User-Agent' => 'cf_app_discovery - GDS - RE',
       }
     end
 
@@ -29,7 +29,7 @@ module StubbableEndpoint
 
     def response_body
       {
-        resources: []
+        resources: [],
       }
     end
   end

--- a/spec/stubbable_endpoint/routes_4.rb
+++ b/spec/stubbable_endpoint/routes_4.rb
@@ -9,18 +9,18 @@ module StubbableEndpoint
     end
 
     def url
-      'http://api.example.com/v2/apps/app-4-guid/routes'
+      "http://api.example.com/v2/apps/app-4-guid/routes"
     end
 
     def request_headers
       {
-        'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE',
+        "Authorization" => "bearer dummy-oauth-token",
+        "User-Agent" => "cf_app_discovery - GDS - RE",
       }
     end
 
     def request_body
-      ''
+      ""
     end
 
     def response_headers

--- a/spec/stubbable_endpoint/shared_domains.rb
+++ b/spec/stubbable_endpoint/shared_domains.rb
@@ -27,7 +27,7 @@ module StubbableEndpoint
 
     def response_body
       {
-        resources: []
+        resources: [],
       }
     end
   end

--- a/spec/stubbable_endpoint/space_1.rb
+++ b/spec/stubbable_endpoint/space_1.rb
@@ -15,7 +15,7 @@ module StubbableEndpoint
     def request_headers
       {
         'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE'
+        'User-Agent' => 'cf_app_discovery - GDS - RE',
       }
     end
 
@@ -31,8 +31,8 @@ module StubbableEndpoint
       {
         entity: {
           name: 'test-space-name',
-          organization_url: '/v2/organizations/example-org-guid'
-        }
+          organization_url: '/v2/organizations/example-org-guid',
+        },
       }
     end
   end

--- a/spec/stubbable_endpoint/space_1.rb
+++ b/spec/stubbable_endpoint/space_1.rb
@@ -9,18 +9,18 @@ module StubbableEndpoint
     end
 
     def url
-      'http://api.example.com/v2/spaces/example-space-guid'
+      "http://api.example.com/v2/spaces/example-space-guid"
     end
 
     def request_headers
       {
-        'Authorization' => 'bearer dummy-oauth-token',
-        'User-Agent' => 'cf_app_discovery - GDS - RE',
+        "Authorization" => "bearer dummy-oauth-token",
+        "User-Agent" => "cf_app_discovery - GDS - RE",
       }
     end
 
     def request_body
-      ''
+      ""
     end
 
     def response_headers
@@ -30,8 +30,8 @@ module StubbableEndpoint
     def response_body
       {
         entity: {
-          name: 'test-space-name',
-          organization_url: '/v2/organizations/example-org-guid',
+          name: "test-space-name",
+          organization_url: "/v2/organizations/example-org-guid",
         },
       }
     end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.
- Diff linting, as was being done in the Travis config, was removed in
  recent versions of `govuk-lint`.

---

I disabled some cops that it was complaining about that I didn't
entirely understand the ramifications of the changes for - I don't want
to break the app!