### PR TITLE
fix broken concourse resource

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -7,6 +7,7 @@ defaults: &defaults
   stack: cflinuxfs3
   services:
     - prometheus-targets-access
+  path: .
   env:
     AWS_REGION: eu-west-1
     API_ENDPOINT: https://api.cloud.service.gov.uk

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -7,6 +7,7 @@ defaults: &defaults
   stack: cflinuxfs3
   services:
     - prometheus-targets-access-staging
+  path: .
   env:
     AWS_REGION: eu-west-1
     API_ENDPOINT: https://api.cloud.service.gov.uk


### PR DESCRIPTION
The concourse pipeline (in
prometheus-aws-configuration-beta/pipeline.yml) broke when we upgraded
to concourse 5.7.0.  There are various problems:

  - we use the default `cf` resource rather than pinning a specific
    version in `resource_types` :(
     - and it's hard to find out what the old version we were using
       even was D:
  - we specify the `path` parameter on our resource update
  - we have multiple apps in our manifest

A [recent update to the concourse cf-resource][1] changed how we push
apps, so that when you specify `path` it adds a `-p .` parameter to
the cf command line.  The cf cli then barfs with the error:

    Incorrect Usage: Command line flags (except -f and --no-start) cannot be applied when pushing multiple apps from a manifest file.

If we remove the `path`, it still fails, because it can't find the
code.

The fix is to specify the path as `.` in the manifest here, then
update the pipeline (in the other repo) to remove the `path`
parameter.

[1]: https://github.com/concourse/cf-resource/commit/e07c4c5a154cfb6a2950d84c07b53a70c7513e7d